### PR TITLE
feat!: include node 10 types

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,17 +37,17 @@
       "require": {
         "types": "./dist/rollup.d.cts",
         "default": "./dist/rollup.cjs"
-      }
-    },
-    "./package.json": "./package.json"
+      },
+      "default": "./dist/rollup.mjs"
+    }
   },
-  "main": "./dist/index.cjs",
+  "main": "./dist/index.js",
   "module": "./dist/index.mjs",
-  "types": "./dist/index.d.cts",
+  "types": "./dist/index.d.ts",
   "typesVersions": {
     "*": {
       "rollup": [
-        "./dist/rollup.cts"
+        "./dist/rollup.ts"
       ]
     }
   },


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide info about the "what" this PR is solving. -->
Adding the Rollup plugin to `tsup` cannot resolve `import { FixDtsDefaultCjsExportsPlugin } from 'fix-dts-default-cjs-exports/rollup'`, it is using`node 10` module resolution.

### Linked Issues

<!-- e.g. fixes #123 -->

### Additional Context

<!-- Is there anything you would like the reviewers to focus on? -->
